### PR TITLE
Avoid trying to inject icons that are empty at compile time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error no type defs for camel-to-kebab
 import camelToKebabCase from "camel-to-kebab";
 import type { ASTElement } from "vue-template-compiler";
 import { iconMaps } from "./vuetifyIconProps";
@@ -49,6 +48,8 @@ export function getIconInjector(
   return {
     // Handle <v-icon>mdi-*</v-icon>
     transformNode(el: ASTElement) {
+      if (!el.children[0]) return;
+   
       // Check for correct Tag
       if (camelToKebabCase(el.tag) === "v-icon" && el.children[0].text) {
         // Replace

--- a/src/shims-camel.d.ts
+++ b/src/shims-camel.d.ts
@@ -1,0 +1,4 @@
+declare module "camel-to-kebab" {
+    const fn: (input: string) => string;
+    export default fn;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "pretty": true,
     "baseUrl": "."
   },
+  "include": ["./src/*.d.ts"],
   "exclude": ["./node_modules"],
   "files": ["./src/index.ts"]
 }


### PR DESCRIPTION
Fix compile time error caused by using dynamic expressions like `<v-icon v-text="somevariable" />`. checks if `el.children` is empty or not.

Also type declaration for 'camel-to-kebab'